### PR TITLE
Avoid loading all the intances in memory when running the anonymization

### DIFF
--- a/hattori/__init__.py
+++ b/hattori/__init__.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 __author__ = 'Marc Galofré'
 __email__ = 'mgalofre@apsl.net'
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/hattori/base.py
+++ b/hattori/base.py
@@ -5,6 +5,7 @@ import logging
 from tqdm import tqdm
 from six import string_types
 from django.conf import settings
+from django.core.paginator import Paginator
 from bulk_update.helper import bulk_update
 from faker import Faker
 
@@ -36,15 +37,34 @@ class BaseAnonymizer:
 
     def run(self, batch_size):
         instances = self.get_query_set()
-        instances_processed, count_instances, count_fields = self._process_instances(instances)
-        bulk_update(instances_processed, update_fields=[attrs[0] for attrs in self.attributes], batch_size=batch_size)
+
+        # When there are memory constraints is better to paginate the
+        # processing of the instances
+        paginator = Paginator(instances, batch_size)
+        count_instances = 0
+        count_fields = 0
+
+        progress_bar = tqdm(desc="Processing", total=paginator.num_pages)
+        for num_page in paginator.page_range:
+            subinstances = paginator.page(num_page)
+            instances_processed, count_subinstances, count_subfields = self._process_instances(subinstances)
+            bulk_update(
+                instances_processed,
+                update_fields=[attrs[0] for attrs in self.attributes],
+                batch_size=batch_size
+            )
+
+            count_instances += count_subinstances
+            count_fields += count_subfields
+
+            progress_bar.update(1)
+        progress_bar.close()
         return len(self.attributes), count_instances, count_fields
 
     def _process_instances(self, instances):
         count_fields = 0
         count_instances = 0
 
-        progress_bar = tqdm(desc="Processing", total=instances.count())
         for model_instance in instances:
             for field_name, replacer in self.attributes:
                 if callable(replacer):
@@ -56,8 +76,7 @@ class BaseAnonymizer:
                 setattr(model_instance, field_name, replaced_value)
                 count_fields += 1
             count_instances += 1
-            progress_bar.update(1)
-        progress_bar.close()
+
         return instances, count_instances, count_fields
 
     @staticmethod


### PR DESCRIPTION
I have moved the batch processing to the run method. This is because under memory constraints this application cannot be executed if the number of instances is big.

By paginating, one can load in memory only the number of instances the command can process in each iteration making the application usable in more scenarios.